### PR TITLE
Support (optional) `multi_check` to further improve performance

### DIFF
--- a/dom_control/lib/dom_control/config.rb
+++ b/dom_control/lib/dom_control/config.rb
@@ -1,8 +1,9 @@
 class DomControl::Config
-  attr_accessor :check
+  attr_accessor :check, :check_multi
   attr_accessor :serialize_resource_as
 
   def initialize
+    self.check_multi           = nil
     self.check                 = ->(key, subject) { false }
     self.serialize_resource_as = :dom_id
   end

--- a/dom_control/lib/dom_control/processor.rb
+++ b/dom_control/lib/dom_control/processor.rb
@@ -4,24 +4,71 @@ class DomControl::Processor
     return response unless headers["Content-Type"].start_with?("text/html")
 
     # TODO: currently assumes the body contains a ActionDispatch::Response::RackBody
-    [status, headers, [process_html(body.body, check: request_env['dom_control.check'])]]
+    [
+      status,
+      headers,
+      [
+        process_html(
+          body.body,
+          check_multi: request_env['dom_control.check_multi'],
+          check: request_env['dom_control.check']
+        )
+      ]
+    ]
   end
 
-  def self.process_html(html, check: nil)
+  def self.process_html(html, check_multi: nil, check: nil)
+    check_multi ||= DomControl.config.check_multi
     check ||= DomControl.config.check
 
     ActiveSupport::Notifications.instrument "dom_control.process_html" do
       doc = Nokogiri::HTML(html)
       nodes = doc.search('.//domcontrol')
-      nodes.each do |node|
-        key            = node['check'] || node['unless']
-        resource       = node['resource']
-        expected_value = node['check'].present?
-        value          = check.call(key, resource)
 
-        node.remove if value != expected_value
+      # Build Node Checks from DomControl nodes
+      node_checks = nodes.map { |node| NodeCheck.new(node: node) }
+
+      # do (optional) multi check
+      check_multi.call(node_checks) if check_multi
+
+      # resolve remaining single checks
+      node_checks.each do |node_check|
+        if node_check.unset_value?
+          check.call(node_check)
+        end
       end
+
+      # remove nodes
+      node_checks.each do |node_check|
+        if node_check.remove?
+          node_check.node.remove
+        end
+      end
+
+      # generate html
       doc.to_html
+    end
+  end
+
+  NodeCheck = Struct.new(:node, :value, keyword_init: true) do
+    def key
+      node['check'] || node['unless']
+    end
+
+    def resource
+      node['resource']
+    end
+
+    def expected_value
+      node['check'].present?
+    end
+
+    def remove?
+      value != expected_value
+    end
+
+    def unset_value?
+      value.nil?
     end
   end
 end

--- a/dom_control/lib/dom_control/rails/controller_extensions.rb
+++ b/dom_control/lib/dom_control/rails/controller_extensions.rb
@@ -6,10 +6,18 @@ module DomControl::Rails::ControllerExtensions
   end
 
   class_methods do
+    def dom_control_check_multi(&block)
+      before_action do
+        request.env['dom_control.check_multi'] = ->(checks) do
+          instance_exec(checks, &block)
+        end
+      end
+    end
+
     def dom_control_check(&block)
       before_action do
-        request.env['dom_control.check'] = ->(key, subject) do
-          instance_exec(key, subject, &block)
+        request.env['dom_control.check'] = ->(check) do
+          instance_exec(check, &block)
         end
       end
     end


### PR DESCRIPTION
Support checking multiple DomControl nodes at once to allow the caching mechanism to use `Rails.cache.multi_read` -- minimizing the back and forth from your cache, and further optimizing.

If a value isn't resolved after the `dom_control_multi_check`, use the single check to backfill values. The single `check` should almost always be used for the cache writes, and `multi_check` is for more performant reads.

Also, extract a `NodeCheck` struct (I'm open to a better name on this) to be used to pass around between the single `dom_control_check` and the new `dom_control_multi_check`.


In my testing, this was often 2-3X faster (not benchmarked, just through observing numbers) on warm cache reads, and only very slightly slower (~1.1X) on cold caches.